### PR TITLE
Prevent Special Event Rendering When Fake Token Sent

### DIFF
--- a/ngApp/src/app/special-events/special-events.component.html
+++ b/ngApp/src/app/special-events/special-events.component.html
@@ -1,4 +1,4 @@
-<div class="row mt-5">
+<div class="row mt-5" *ngIf="validate">
     <div class="col-md-4 mb-3" *ngFor="let event of specialEvents">
       <div class="card text-center">
         <div class="card-body">

--- a/ngApp/src/app/special-events/special-events.component.ts
+++ b/ngApp/src/app/special-events/special-events.component.ts
@@ -11,7 +11,7 @@ import { Router } from '@angular/router'
 export class SpecialEventsComponent implements OnInit {
   
   specialEvents = []
-
+  validate:Boolean = false
   constructor(private _eventService: EventService,
               private _router: Router) { }
 
@@ -19,7 +19,10 @@ export class SpecialEventsComponent implements OnInit {
   ngOnInit() {
     this._eventService.getSpecialEvents()
       .subscribe(
-        res => this.specialEvents = res,
+        (res) => {
+          this.specialEvents = res
+          this.validate = true;
+        },
         err => {
           if( err instanceof HttpErrorResponse ) {
             if (err.status === 401) {


### PR DESCRIPTION
What Problem happening is When You sent the Fake token then Special Content gets render for just few ms , By this little change it will be avoided 